### PR TITLE
feat: search for a particular brother

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,13 +37,17 @@
 <body onload="draw();">
 
 <h1>Theta Chi Family Tree</h1>
-Color-coding:
+<p>Color-coding:
 <select id="layout">
   <option value="family">family</option>
   <option value="pledgeClass">pledge class</option>
   <option value="active">active vs. inactive</option>
-</select><br/>
-<br />
+</select></p>
+<div>
+  <input type="text" id="searchbox" placeholder="Brother's name...">
+  <button id="searchbutton">Search</button>
+</div>
+<br/>
 
 <div id="mynetwork"></div>
 
@@ -53,6 +57,27 @@ Color-coding:
   dropdown.onchange = function() {
     draw();
   }
+
+  function search() {
+    var query = $('#searchbox').val();
+    var success = findBrother(query);
+
+    // Indicate if the search succeeded or not.
+    if (success) {
+      $('#searchbox').css('color', 'black');
+    } else {
+      $('#searchbox').css('color', 'red');
+    }
+  }
+  document.getElementById("searchbox").onkeypress = function(e) {
+    if (!e) e = window.event;
+    var keyCode = e.keyCode || e.which;
+    if (keyCode === '13' || keyCode === 13 /* Enter */) {
+      search();
+    }
+  };
+
+  document.getElementById("searchbutton").onclick = search;
 </script>
 </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -156,6 +156,35 @@ function createNodes() {
   });
 }
 
+/**
+ * Searches for the specific brother (case-insensitive, matches any substring).
+ * If found, this zooms the network to focus on that brother's node.
+ *
+ * Returns whether or not the search succeeded. This always returns `true` for
+ * an empty query.
+ */
+function findBrother(name) {
+  if (!name) return true; // Don't search for an empty query.
+  // This requires the network to be instantiated, which implies `nodes` has
+  // been populated.
+  if (!network) return false;
+
+  var lowerCaseName = name.toLowerCase();
+  var found = nodes.find(function (element) {
+    // return element.name === name;
+    return element.name.toLowerCase().includes(lowerCaseName);
+  });
+  if (found) {
+    network.focus(found.id, {
+      scale: 0.9,
+      animation: true,
+    });
+    network.selectNodes([ found.id ]);
+    return true;
+  }
+  return false; // Could not find a match
+}
+
 function draw() {
   destroy();
   createNodes();


### PR DESCRIPTION
This adds a search box to the HTML, as well as functionality to search
for an arbitrary brother in the graph.

Search queries can be any substring of a brother's name,
case-insensitive. If a search succeeds, the graph zooms in and selects
the brother's node. If a search fails, the search text is highlighted in
red.

Test: manual