### PR TITLE
Hold aspect ratio with CSS

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -7,10 +7,17 @@ body {
   font-family: Junction, sans;
   text-align: center;
 }
+/* Aspect ratio based on https://stackoverflow.com/a/10441480 */
 #mynetwork {
+  position: absolute;
+  top: 0; bottom: 0; left: 0; right: 0;
+
   background-image: url("../resources/thetachiflagmodified.jpg");
   background-size: 100%;
-  width: 100%;
-  height: 60em;
   border: 1px solid lightgrey;
+}
+div.stretchy-wrapper {
+  width: 100%;
+  padding-bottom: 66%; /* 3:2, the flag's aspect ratio */
+  position: relative;
 }

--- a/index.html
+++ b/index.html
@@ -30,7 +30,9 @@
 </div>
 <br/>
 
+<div class="stretchy-wrapper">
 <div id="mynetwork"></div>
+</div>
 
 <p id="selection"></p>
 </body>

--- a/main.js
+++ b/main.js
@@ -276,16 +276,6 @@ function draw() {
 }
 
 $(document).ready(function () {
-  // Size the network appropriately
-  function onZoom() {
-    var ratio = 2 / 3; // the aspect ratio of the background image
-    var cw = $('#mynetwork').width();
-    $('#mynetwork').css({ 'height': (cw * ratio) + 'px' });
-  }
-  // Apply this when the document loads, or window resizes
-  $(document).ready(onZoom);
-  $(window).resize(onZoom);
-
   // Start the first draw
   draw();
 


### PR DESCRIPTION
This uses CSS (padding-bottom) to hold the Network to the 3:2 aspect
ratio (the ratio of the flag image), replacing the JavaScript code from
before.

This might help resolve issue #16, but it's hard enough to reproduce
that I'm not sure.

Issue #16