### PR TITLE
chore: switch to GitHub actions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,27 @@
+# Security Policy
+
+Thank you for reaching out about security! Please note that this project is
+maintained on a best-effort basis, however I still intend to prioritize
+reviewing and addressing security issues.
+
+## Supported Versions
+
+This software is released at https://nfischer.github.io/framily-tree/. I only
+intend to publish security fixes to the GitHub pages instance of this site. I do
+not currently publish this package on npm nor do I release versions for other
+modules to depend against.
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities to ntfschr@gmail.com. I should respond
+within a few days. Although it's not strictly required, it helps me out if you
+can include any proof of concept exploit code, suggested fix, etc.
+
+**Please do not publicly disclose the suspected vulnerability** until I have a
+chance to review your report. I'd like a chance to patch the code before the
+issue is known to the public.
+
+Please **only** use this email for security issues. It's also OK to use the
+email if you're legitimately unsure if this is a security issue (better safe
+than sorry). But for all other non-security issues, please use the GitHub issue
+tracker.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,27 @@
+name: CI
+on:
+  - push
+  - pull_request
+jobs:
+  test:
+    name: Node.js ${{ matrix.node-version }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version:
+          - 10
+          - 12
+          - 14
+          - 16
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm install
+      - run: npm run test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Framily tree
 
+[![Build Status](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Factions-badge.atrox.dev%2Fnfischer%2Fframily-tree%2Fbadge%3Fref%3Dmain&style=flat-square)](https://actions-badge.atrox.dev/nfischer/framily-tree/goto?ref=main)
+
+[![Try online](https://img.shields.io/badge/try_it-online!-yellow.svg?style=flat-square)](https://nfischer.github.io/framily-tree)
+
 Check it out [online](https://nfischer.github.io/framily-tree).
 
 See the data in the [Google

--- a/package.json
+++ b/package.json
@@ -26,5 +26,8 @@
     "eslint-plugin-import": "^1.11.1",
     "http-server": "^0.12.1",
     "spreadsheet-to-json": "^2.0.0"
+  },
+  "engines": {
+    "node": ">=10"
   }
 }


### PR DESCRIPTION
This copies over a basic .github/ folder:

* Basic issue template
* Generic SECURITY.md
* GitHub actions workflow adapted from ShellJS (tests node LTS versions >= 10.0)
* GitHub actions badge for README.md