### PR TITLE
chore: add node v18 to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,7 @@ jobs:
           - 12
           - 14
           - 16
+          - 18
         os:
           - ubuntu-latest
           - macos-latest


### PR DESCRIPTION
No change to logic. This adds Node v18 to CI. This is the latest LTS release.