### PR TITLE
chore: add node v20 to CI testing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,7 @@ jobs:
           - 14
           - 16
           - 18
+          - 20
         os:
           - ubuntu-latest
           - macos-latest


### PR DESCRIPTION
No change to logic. This adds node v20 to the testing matrix.