### PR TITLE
Docs: refactor links for easier forking

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,9 @@
 # Framily tree
 
-[![GitHub Actions](https://img.shields.io/github/actions/workflow/status/nfischer/framily-tree/main.yml?style=flat-square&logo=github)](https://github.com/nfischer/framily-tree/actions/workflows/main.yml)
-[![Try online](https://img.shields.io/badge/try_it-online!-yellow.svg?style=flat-square)](https://nfischer.github.io/framily-tree)
+[![GitHub Actions][Actions badge]][GitHub Workflow]
+[![Try online](https://img.shields.io/badge/try_it-online!-yellow.svg?style=flat-square)][GitHub Pages]
 
-Check it out [online](https://nfischer.github.io/framily-tree).
-
-See the data in the [Google
-Spreadsheet](https://docs.google.com/spreadsheets/d/1h6dVJKtETWX3Kr9PT6EaLu0gGavdi8Gnj4IlX155pfY/edit?usp=sharing).
+Check it out [online][GitHub Pages].
 
 ## What is this?
 
@@ -20,6 +17,9 @@ history:
    tree
  * Play around with graph nodes (they bounce around and collide with each other
    using a physics engine!)
+
+This family tree is entirely data-driven and easy to update. Data is pulled from
+a [google spreadsheet].
 
 ## How does it work?
 
@@ -41,6 +41,16 @@ All original source files are licensed under the MIT license. All dependencies
 are licensed under their respective open source licenses. The Theta Chi flag
 image was downloaded from [this
 site](https://upload.wikimedia.org/wikipedia/en/d/df/OX_Flag.png). The data
-displayed on this web page is populated by [this google
-spreadsheet](https://docs.google.com/spreadsheets/d/1h6dVJKtETWX3Kr9PT6EaLu0gGavdi8Gnj4IlX155pfY/edit?usp=sharing)
-and is property of Theta Chi Fraternity Beta Alpha chapter and its initiates.
+displayed on this web page is populated by this [google spreadsheet] and is
+property of Theta Chi Fraternity Beta Alpha chapter and its initiates.
+
+<!--
+  Forking instructions: if you are forking this project for your own
+  fraternity, you will need to change these links to point to the right data for
+  your project:
+-->
+
+[Actions badge]: https://img.shields.io/github/actions/workflow/status/nfischer/framily-tree/main.yml?style=flat-square&logo=github
+[GitHub Workflow]: https://github.com/nfischer/framily-tree/actions/workflows/main.yml
+[GitHub Pages]: https://nfischer.github.io/framily-tree
+[google spreadsheet]: https://docs.google.com/spreadsheets/d/1h6dVJKtETWX3Kr9PT6EaLu0gGavdi8Gnj4IlX155pfY/edit?usp=sharing

--- a/scripts/getData.js
+++ b/scripts/getData.js
@@ -2,6 +2,11 @@ var extractSheets = require('spreadsheet-to-json').extractSheets;
 
 var fs = require('fs');
 
+// Forking instructions: if you are forking this project for your own
+// fraternity, you will need to change the SPREADSHEET_ID to match the URL of
+// your new Google spreadsheet:
+var SPREADSHEET_ID = '1h6dVJKtETWX3Kr9PT6EaLu0gGavdi8Gnj4IlX155pfY';
+
 var apiKey;
 try {
   apiKey = fs.readFileSync('local-api-key.txt', 'utf-8').trimRight('\n');
@@ -13,7 +18,7 @@ try {
 }
 
 extractSheets({
-  spreadsheetKey: '1h6dVJKtETWX3Kr9PT6EaLu0gGavdi8Gnj4IlX155pfY',
+  spreadsheetKey: SPREADSHEET_ID,
   credentials: apiKey,
   sheetsToExtract: ['Sheet1'],
 },


### PR DESCRIPTION
This moves some of the project-specific links (ex. references to my repo, the spreadsheet ID) to a single part of the project. This should match up with the instructions at
https://github.com/nfischer/framily-tree/wiki/Forking-instructions.