### PR TITLE
chore: add CODECOV_TOKEN secret

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,9 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: npm install
       - run: npm run test
-      - uses: codecov/codecov-action@v2
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           fail_ci_if_error: true


### PR DESCRIPTION
No change to logic. This adds the CODECOV_TOKEN secret to the GitHub workflow. This is meant to resolve the error messages where GitHub runs can't send results to Codecov.

Following this guide: https://docs.codecov.com/docs/adding-the-codecov-token