### PR TITLE
chore: drop node 12/14 on macOS and add node 22

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,10 +15,16 @@ jobs:
           - 16
           - 18
           - 20
+          - 22
         os:
           - ubuntu-latest
           - macos-latest
           - windows-latest
+        exclude:
+          - node-version: 12
+            os: macos-latest
+          - node-version: 14
+            os: macos-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2


### PR DESCRIPTION
Node v22 is available as LTS, so add that to the list.

Node v12 and v14 are no longer supported on macOS on GitHub actions.