### PR TITLE
feat: support iterating through search matches

### DIFF
--- a/main.js
+++ b/main.js
@@ -28,6 +28,8 @@ var edgesGlobal;
 var nodesDataSet;
 var edgesDataSet;
 
+var previousSearchFind;
+
 var familyColorGlobal = {};
 var pledgeClassColorGlobal = {};
 
@@ -240,12 +242,21 @@ function createNodesHelper() {
   edgesDataSet = new vis.DataSet(edgesGlobal);
 }
 
-function findBrother(name, nodes) {
+function findBrother(name, nodes, prevElem) {
   var lowerCaseName = name.toLowerCase();
-  var found = nodes.find(function (element) {
+  var matches = nodes.filter(function (element) {
     return element.name.toLowerCase().includes(lowerCaseName);
   });
-  return found;
+  if (matches.length === 0) {
+    return undefined;
+  }
+
+  var idx = 0;
+  if (prevElem) {
+    idx = matches.indexOf(prevElem);
+    idx = (idx + 1) % matches.length;
+  }
+  return matches[idx];
 }
 
 /**
@@ -262,7 +273,8 @@ function findBrotherHelper(name) {
   // has been populated.
   if (!network) return false;
 
-  var found = findBrother(name, nodesGlobal);
+  var found = findBrother(name, nodesGlobal, previousSearchFind);
+  previousSearchFind = found;
 
   if (found) {
     network.focus(found.id, {

--- a/test/test.js
+++ b/test/test.js
@@ -67,5 +67,16 @@ describe('framily-tree', function () {
       result = main.findBrother('Al', state.nodes);
       result.name.should.equal('Alex Brown');
     });
+
+    it('will advance through multiple matches', function () {
+      var result = main.findBrother('Joe', state.nodes);
+      result.name.should.equal('Joe Smith');
+      // Advance to the next match.
+      result = main.findBrother('Joe', state.nodes, result);
+      result.name.should.equal('Joe NotSmith');
+      // And it also wraps around to the start of the matches.
+      result = main.findBrother('Joe', state.nodes, result);
+      result.name.should.equal('Joe Smith');
+    });
   });
 });


### PR DESCRIPTION
When a search matches multiple brothers, this will now iterate through all matching results when doing subsequent searches.

Example:
 - [Joe] -> "Joe Smith"
 - [Joe] (2nd time) -> "Joe NotSmith"
 - [Joe] (3rd time) -> "Joe Smith" (wrap around)

Fixes: #11
Test: npm test
Test: npm start (check in the browser)