### PR TITLE
refactor: ignore untestable lines of code

### DIFF
--- a/main.js
+++ b/main.js
@@ -3,18 +3,23 @@
 // Mock out dependencies for testing on NodeJS. These are imported in HTML in
 // the browser.
 /* eslint-disable */
+/* istanbul ignore else */
 if (typeof brothers === 'undefined') {
   brothers = require('./relations');
 }
+/* istanbul ignore else */
 if (typeof tinycolor === 'undefined') {
   tinycolor = require('tinycolor2');
 }
+/* istanbul ignore else */
 if (typeof $ === 'undefined') {
   $ = require('jquery');
 }
+/* istanbul ignore else */
 if (typeof vis === 'undefined') {
   vis = require('vis');
 }
+/* istanbul ignore else */
 if (typeof didYouMean === 'undefined') {
   didYouMean = require('didyoumean');
 }
@@ -201,10 +206,10 @@ function createNodes(brothers_) {
   function getFamily(node) {
     node.family = node.family || node.familystarted;
     if (node.family) return node.family;
-    /* istanbul ignore catch */
     try {
       node.family = getFamily(node.big);
     } catch (e) {
+      /* istanbul ignore next */
       node.family = 'unknown';
     }
 
@@ -287,6 +292,7 @@ function findBrotherHelper(name) {
   return false; // Could not find a match
 }
 
+/* istanbul ignore next */
 function draw() {
   createNodesHelper();
 
@@ -376,6 +382,7 @@ if (typeof document !== 'undefined') {
   });
 }
 
+/* istanbul ignore else */
 if (typeof module !== 'undefined' && typeof module.exports !== 'undefined') {
   module.exports.createNodes = createNodes;
   module.exports.createNodesHelper = createNodesHelper;

--- a/relations.js
+++ b/relations.js
@@ -2113,6 +2113,7 @@ var brothers = [
     "pledgeclass": "Fall 2023"
   }
 ];
+/* istanbul ignore else */
 if (typeof module !== 'undefined' && typeof module.exports !== 'undefined') {
   module.exports = brothers;
 }

--- a/scripts/getData.js
+++ b/scripts/getData.js
@@ -54,7 +54,8 @@ function (err, result) {
 
   var str = 'var brothers = ' + JSON.stringify(result, undefined, 2) + ';\n';
   // Turn this into a node module that we can `require()` for testing.
-  str += "if (typeof module !== 'undefined' && typeof module.exports !== 'undefined') {\n"
+  str += '/* istanbul ignore else */\n'
+       + "if (typeof module !== 'undefined' && typeof module.exports !== 'undefined') {\n"
        + '  module.exports = brothers;\n'
        + '}\n';
   fs.writeFileSync('relations.js', str);


### PR DESCRIPTION
No change to logic. This adds `/* istanbul ignore ... */` statements for code paths which are currently not easy to automatically test because the code depends on the browser environment.